### PR TITLE
draft: start rough prototype for designing gallery

### DIFF
--- a/gallery2/entries.yml
+++ b/gallery2/entries.yml
@@ -1,0 +1,24 @@
+- category: Barcharts
+  content:
+   - name: Basic
+     src: examples/geom_bar.ipynb#3
+   - name: With fill
+     src: examples/geom_bar.ipynb#4
+   - name: Flipped
+     src: examples/geom_bar.ipynb#5
+- category: Scatterplots
+  content:
+    - name: Basic
+      src: examples/geom_point.ipynb#3
+    - name: Basic filled
+      src: examples/geom_point.ipynb#5
+    - name: Smooth
+      src: examples/geom_smooth.ipynb#3
+- category: Distributions
+  content:
+    - name: Boxplot
+      src: examples/geom_boxplot.ipynb#5
+    - name: With fill
+      src: examples/geom_bar.ipynb#4
+    - name: Basic density
+      src: examples/geom_density.ipynb#8

--- a/gallery2/index.qmd
+++ b/gallery2/index.qmd
@@ -1,0 +1,164 @@
+---
+title: Gallery
+jupyter: python3
+---
+
+```{python}
+#| include: false
+import base64
+import io
+import re
+from dataclasses import dataclass
+from pathlib import Path
+import yaml
+
+import nbformat
+import PIL.Image
+from nbformat.notebooknode import NotebookNode
+from qrenderer._pandoc.blocks import Meta
+from quartodoc.pandoc.blocks import Blocks, BlockContent, Div
+from quartodoc.pandoc.components import Attr
+from quartodoc.pandoc.inlines import Image, Link
+import os
+
+THIS_DIR = Path(os.getcwd())
+ROOT_DIR = THIS_DIR.parent
+
+# String in code cell that creates an image that will be in the gallery
+EXAMPLES_DIR = ROOT_DIR / "reference" / "examples"
+THUMBNAILS_DIR = Path("thumbnails")
+THUMBNAIL_SIZE = (294, 210)
+
+gallery_page = ROOT_DIR / "gallery/index.qmd"
+word_and_dashes_pattern = re.compile(r"[^\w-]")
+
+## TODO Michael added ----
+def get_src_cell(src: str):
+    nb_path, cell_loc = src.split("#")
+
+    nb = nbformat.read(nb_path, as_version=4)
+    img_cells = list_cell_displays(nb)
+    try:
+        return img_cells[int(cell_loc)][0]
+    except KeyError:
+        raise KeyError(
+            f"Cell number {cell_loc} in the notebook {nb_path} does not have output."
+            " Did you mean one of the following?:"
+            f" {list(img_cells)}"
+        )
+
+
+def list_cell_displays(nb):
+    """Return a dictionary mapping cell index -> display outputs.
+    
+    Note that cells without display outputs are omitted.
+    """
+    nb_cells = nb["cells"]
+    outputs = {}
+    for ii, cell in enumerate(nb_cells):
+        if cell["cell_type"] != "code":
+            continue
+
+        displayed = []
+        for node in cell["outputs"]:
+            if node.output_type == "display_data":
+                displayed.append(node)
+        
+        if displayed:
+            outputs[ii] = displayed
+
+    return outputs
+
+
+## ----
+
+@dataclass
+class GalleryImage:
+    """
+    Gallery Image
+    """
+
+    # The relative path of thumbnail from the gallery
+    thumbnail: Path
+    title: str
+    target: str
+
+    def __str__(self):
+        # card, card-header, card-body create bootstrap components
+        # https://getbootstrap.com/docs/5.3/components/card/
+        #
+        # For a responsive layout, use bootstrap grid classes that select
+        # for different screen sizes
+        # https://getbootstrap.com/docs/5.3/layout/grid/#grid-options
+        out_cls = "card g-col-12 g-col-sm-6 g-col-md-4"
+        in_cls = "card-header"
+        res = Div(
+            [
+                Div(self.title, Attr(None, in_cls.split())),
+                Div(
+                    Link(Image(src=self.thumbnail), target=self.target),
+                    Attr(None, ["card-body"]),
+                ),
+            ],
+            Attr(None, out_cls.split()),
+        )
+        return str(res)
+
+
+def create_thumbnail(output_node: NotebookNode, filepath: Path):
+    """
+    Create a thumbnail for the gallery
+
+    Parameters
+    ----------
+    output_node:
+        Node containing the output image
+    filepath:
+        Where to save the created thumbnail on the filesystem
+    """
+    filepath.parent.mkdir(exist_ok=True, parents=True)
+    thumb_size = THUMBNAIL_SIZE[0] * 2, THUMBNAIL_SIZE[1] * 2
+    img_str = output_node["data"]["image/png"]
+    file = io.BytesIO(base64.decodebytes(img_str.encode()))
+    img = PIL.Image.open(file)
+    img.thumbnail(thumb_size)
+    img.save(filepath)
+```
+
+```{python}
+#| include: false
+entries = yaml.safe_load(open("./entries.yml"))
+source = entries[0]["content"][0]["src"]
+src_cell = get_src_cell(str(ROOT_DIR / "reference" / source))
+
+ttl_outputs = 0
+images = []
+for section in entries:
+    for entry in section["content"]:
+        src_cell = get_src_cell(str(ROOT_DIR / "reference" / entry["src"]))
+        #thumb_path = THIS_DIR / "thumbnails" / f"{ttl_outputs}.png"
+        thumb_path = Path("thumbnails") / f"{ttl_outputs}.png"
+        create_thumbnail(src_cell, thumb_path)
+        ttl_outputs += 1
+        
+        images.append(GalleryImage(thumbnail = thumb_path, title = entry["name"], target = ""))
+```
+
+```{python}
+#| include: false
+# Render the items in the gallery ----
+items = Div(list(map(str, images)), Attr(classes=["gallery", "grid"]))
+
+
+# Render the gallery page ----
+blocks = Blocks([
+    Div(items, Attr(classes=["column-body-outset"])),
+])
+```
+
+```{python}
+#| echo: false
+#| output: asis
+# Create gallery qmd file ----
+print(str(blocks))
+```


### PR DESCRIPTION
This PR is a (very WIP) draft of a gallery. Currently it just reads a yaml file, and then outputs a bunch of plots. It's okay if the final thing doesn't use a yaml file, but...

* it's been helpful for just prototyping what plots could go into the gallery.
* I wanted to avoid having to modify to notebooks, before getting feedback on the gallery content.

I have all of the plots in the API reference pasted in the miro board that I shared. Would love to see whatever plots / categories you'd want on a gallery. (For example, either laid out in miro or feel free to commit here / do separately). I do think it'll be very helpful to spec out the gallery first, before trying to make it all work through carefully formatted notebook examples / metadata in notebooks.