### PR TITLE
ci: deploy pull requests as previews

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,14 @@
+name: Build Website - Pull Request
+
+on:
+  push:
+    pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-site:
+    name: Build site for plotnine.org
+    uses: ./.github/workflows/build.yml
+    with:
+      plotnine-branch: main
+      target-folder: "--pr-${{github.event_name}}"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -9,5 +9,5 @@ jobs:
     name: Build site for plotnine.org
     uses: ./.github/workflows/build.yml
     with:
-      plotnine-branch: main
+      plotnine-branch: release
       target-folder: "--pr-${{github.event_name}}"

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,8 +1,7 @@
 name: Build Website - Pull Request
 
 on:
-  push:
-    pull_request:
+  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR makes pull request docs builds appear in `plotnine.org/--pr-{pr number}`

TODO: I think we need to restrict it to PRs that aren't from forks (not for security, but because they'll fail)