### PR TITLE
Point guide in topnav to guide introduction page

### DIFF
--- a/source/_quarto.yml
+++ b/source/_quarto.yml
@@ -29,7 +29,7 @@ website:
   page-navigation: true
   navbar:
     left:
-      - file: guide/install.qmd
+      - file: guide/introduction.qmd
         text: Guide
       - file: reference/index.qmd
         text: "Reference"


### PR DESCRIPTION
This PR changes the Guide button in the top nav, so it points to the introduction page, rather than the install page.